### PR TITLE
fix(ci): exclude test fixtures from TruffleHog

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
       - name: TruffleHog secret scan
         uses: trufflesecurity/trufflehog@main
         with:
-          extra_args: --only-verified --fail
+          extra_args: --only-verified --fail --exclude-paths=.trufflehog-exclude
 
   audit:
     runs-on: ubuntu-24.04

--- a/.trufflehog-exclude
+++ b/.trufflehog-exclude
@@ -1,0 +1,4 @@
+# Test fixtures with intentionally fake credential patterns
+test-sidecar.mjs
+packages/plugin/src/credential-redactor.test.ts
+packages/proxy/src/credential-store.test.ts


### PR DESCRIPTION
## Summary
- Add `.trufflehog-exclude` to skip test fixture files containing intentionally fake credential patterns
- Update CI workflow to use the exclude list

TruffleHog was flagging FAKE/TEST-prefixed patterns in `test-sidecar.mjs` and `credential-redactor.test.ts`.

## Test plan
- [ ] CI secret-scan job passes (green)
- [ ] lint, typecheck, test jobs still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)